### PR TITLE
Ignore 409 error when reclaiming task when build is finished

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = true

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="bbb",
-    version="1.6.0",
+    version="1.6.1",
     description="Buildbot <-> Taskcluster Bridge",
     author="Mozilla Release Engineering",
     packages=["bbb", "bbb.schemas"],

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     flake8
     pytest
     pytest-cov
-    pytest-capturelog
+    pytest-catchlog
     mock
 
 commands=


### PR DESCRIPTION
We can ignore a 409 error from Taskcluster when calling reclaimTask for
a finished build. The build has already finished, and we can let
BBListener handle the finished event. In addition, if we don't ignore
the 409 error here, the generic taskcluster exception  handler will try
and cancel the buildbot build, which can take a long time.

Other minor changes:
- Submit timing information for how long it takes to refresh the list
of allowed builders

- Replace pytest-capturelog with pytest-catchlog to fix some pytest
warnings.