### PR TITLE
Bug 1391102 - No workers launched for end of release automation jobs

### DIFF
--- a/bbb/servicebase.py
+++ b/bbb/servicebase.py
@@ -250,18 +250,16 @@ class BuildbotDb(object):
             log.info("Created buildset_property %s=%s", key, value)
 
     @statsd.timer('bbdb.injectTask')
-    def injectTask(self, taskid, runid, task):
+    def injectTask(self, taskid, scheduled, task):
         payload = task["payload"]
         # Create a sourcestamp if necessary
         sourcestamp = payload.get('sourcestamp', {})
 
         sourcestampid = self.createSourceStamp(sourcestamp)
 
-        # TODO: submitted_at should be now, or the original task?
-        # using orginal task's date for now
         # Note: The reason field should not be changed. It is used
         # by other systems to detect bbb jobs.
-        submitted_at = parseDateString(task['created'])
+        submitted_at = parseDateString(scheduled)
         q = self.buildsets_table.insert().values(
             external_idstring="taskId:{}".format(taskid),
             reason="Created by BBB for task {0}".format(taskid),

--- a/bbb/services.py
+++ b/bbb/services.py
@@ -531,6 +531,7 @@ class TCListener(ListenerService):
 
         taskid = data["status"]["taskId"]
         runid = data["status"]["runs"][-1]["runId"]
+        scheduled = data["status"]["runs"][-1]["scheduled"]
 
         tc_task = self.tc_queue.task(taskid)
         buildername = tc_task["payload"].get("buildername")
@@ -596,7 +597,7 @@ class TCListener(ListenerService):
             log.info("task %s: run %s: injecting task into bb", taskid, runid)
             try:
                 self.bbb_db.createTask(taskid, runid, parseDateString(tc_task["created"]))
-                brid = self.buildbot_db.injectTask(taskid, runid, tc_task)
+                brid = self.buildbot_db.injectTask(taskid, scheduled, tc_task)
                 self.bbb_db.updateBuildRequestId(taskid, runid, brid)
                 log.info("task %s: run %s: buildrequest %s: injected into bb",
                          taskid, runid, brid)

--- a/bbb/test/test_services.py
+++ b/bbb/test/test_services.py
@@ -722,7 +722,7 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0},
+                {"runId": 0, "scheduled": 10},
             ],
         }}
 
@@ -804,7 +804,7 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0},
+                {"runId": 0, "scheduled": 10},
             ],
         }}
 
@@ -876,7 +876,7 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0},
+                {"runId": 0, "scheduled": 10},
             ],
         }}
 
@@ -902,7 +902,7 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0},
+                {"runId": 0, "scheduled": 10},
             ],
         }}
 
@@ -1165,7 +1165,7 @@ INSERT INTO buildrequests
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0},
+                {"runId": 0, "scheduled": 10},
             ],
         }}
 
@@ -1200,7 +1200,7 @@ def test_integrity_error(fake_now, caplog):
     data = {"status": {
         "taskId": taskid,
         "runs": [
-            {"runId": 1},
+            {"runId": 1, "scheduled": 10},
         ],
     }}
     tclistener = TCListener(

--- a/bbb/test/test_services.py
+++ b/bbb/test/test_services.py
@@ -868,8 +868,8 @@ SELECT * FROM buildsets;"""))
         self.assertEqual(bbb_state[0].createdDate, 23)
         self.assertEqual(bbb_state[0].processedDate, 34)
         self.assertEqual(bbb_state[0].takenUntil, None)
-        # TODO: verify buildrequest/buildsets have correct submitted_at here ?
-        # what is the desired behaviour anyway ?
+        # we don't update the buildbot db for reruns, so submitted_at is unchanged and we
+        # don't attempt to test that here
 
     def testHandlePendingIgnoredBuilder(self):
         taskid = makeTaskId()

--- a/bbb/test/test_services.py
+++ b/bbb/test/test_services.py
@@ -667,7 +667,7 @@ class TestTCListener(unittest.TestCase):
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0, "scheduled": 10},
+                {"runId": 0, "scheduled": 60},
             ],
         }}
 
@@ -700,7 +700,7 @@ class TestTCListener(unittest.TestCase):
         self.assertEqual(buildrequests[0].id, 1)
         self.assertEqual(buildrequests[0].buildername, "builder good name")
         self.assertEqual(buildrequests[0].priority, 0)
-        self.assertEqual(buildrequests[0].submitted_at, 10)
+        self.assertEqual(buildrequests[0].submitted_at, 60)
         properties = self.tclistener.buildbot_db.buildset_properties_table.select().execute().fetchall()
         self.assertItemsEqual(properties, [
             (1, u"taskId", u'["{}", "bbb"]'.format(taskid)),
@@ -714,7 +714,7 @@ SELECT * FROM buildsets;"""))
         for row in bb_state:
             reason = row[2][0:-len(taskid)]
             self.assertEqual(reason, u'Created by BBB for task ')
-            self.assertEqual(row['submitted_at'], 10)
+            self.assertEqual(row['submitted_at'], 60)
 
     @patch("arrow.now")
     def testHandlePendingNotAuthorizedRestrictedBuilder(self, fake_now):
@@ -722,7 +722,7 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0, "scheduled": 10},
+                {"runId": 0, "scheduled": 60},
             ],
         }}
 
@@ -754,7 +754,7 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0, "scheduled": 10},
+                {"runId": 0, "scheduled": 60},
             ],
         }}
 
@@ -788,7 +788,7 @@ SELECT * FROM buildsets;"""))
         self.assertEqual(buildrequests[0].id, 1)
         self.assertEqual(buildrequests[0].buildername, "i'm a good builder")
         self.assertEqual(buildrequests[0].priority, 1)
-        self.assertEqual(buildrequests[0].submitted_at, 10)
+        self.assertEqual(buildrequests[0].submitted_at, 60)
         properties = self.tclistener.buildbot_db.buildset_properties_table.select().execute().fetchall()
         self.assertItemsEqual(properties, [
             (1, u"taskId", u'["{}", "bbb"]'.format(taskid)),
@@ -804,7 +804,7 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0, "scheduled": 10},
+                {"runId": 0, "scheduled": 60},
             ],
         }}
 
@@ -841,8 +841,8 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0, "scheduled": 10},
-                {"runId": 1, "scheduled": 30},
+                {"runId": 0, "scheduled": 60},
+                {"runId": 1, "scheduled": 100},
             ],
         }}
         self.tclistener.tc_queue.task.return_value = {
@@ -876,7 +876,7 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0, "scheduled": 10},
+                {"runId": 0, "scheduled": 60},
             ],
         }}
 
@@ -902,7 +902,7 @@ SELECT * FROM buildsets;"""))
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0, "scheduled": 10},
+                {"runId": 0, "scheduled": 60},
             ],
         }}
 
@@ -1165,7 +1165,7 @@ INSERT INTO buildrequests
         data = {"status": {
             "taskId": taskid,
             "runs": [
-                {"runId": 0, "scheduled": 10},
+                {"runId": 0, "scheduled": 60},
             ],
         }}
 
@@ -1200,7 +1200,7 @@ def test_integrity_error(fake_now, caplog):
     data = {"status": {
         "taskId": taskid,
         "runs": [
-            {"runId": 1, "scheduled": 10},
+            {"runId": 1, "scheduled": 60},
         ],
     }}
     tclistener = TCListener(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="bbb",
-    version="1.6.4",
+    version="1.6.5",
     description="Buildbot <-> Taskcluster Bridge",
     author="Mozilla Release Engineering",
     packages=["bbb", "bbb.schemas"],


### PR DESCRIPTION
I think this will fix the problem we're having in bug 1391102, where TC tasks have creation times more than a day ago and result in buildrequests which are ignored by aws_watch_pending.py. It uses  `scheduled` time from the most recent run instead, since that's the actual time the scheduler marked the job as pending. Effectively that's Run 0 as the modified code is used when the bridge doesn't have a record of the task in it's own db.

There's no attempt to update submitted_at if the task is rerun at some later time, which might just be kicking the can down the road and around the corner (case). Do you think that's likely to be an issue ? I suspect not for the way the release automation is normally used but this is a new rodeo for me.